### PR TITLE
Undo functionality though clickable notification

### DIFF
--- a/src_chrome/eventPage.js
+++ b/src_chrome/eventPage.js
@@ -319,7 +319,24 @@ function showUndoNotification(bookmarkTreeNode, oldBookmarkUrl){
 }
 
 /*
- * Todo: write documentation
+ * Create a Nofitifaction object that will automatically disappear after a
+ * given time without the need for any user interaction.
+ *
+ * @param {String} title the title of the notification.
+ *
+ * @param {String} body the body of the notification.
+ *
+ * @param {int} timeout the time in ms after which the notification should
+ * automatically disappear once it is displayed.
+ *
+ * @returns {Notification} The returned notification can be displayed using the
+ * show() method. It makes use of the ondisplay attribute to automatically
+ * close it again after the given time has lapsed. 
+ *
+ * See also:
+ * http://www.chromium.org/developers/design-documents/desktop-notifications/api-specification
+ * http://developer.chrome.com/extensions/notifications.html
+ *
  */
 function createTimedOutNotification(title, body, timeout){
   var notification = webkitNotifications.createNotification(


### PR DESCRIPTION
Hi Ian,

I'm interested in your though on the following approach for an undo feature.

Your idea of the extension is to interfere as less as possible with the user. Ideally it should be invisible. Hence User interaction should be minimized. 

With this in mind I included the functionality to _optionally_ click the update notification in case the user determines that the wrong bookmark has been updated. So if all works as expected then the user interaction is limited to one click, followed by a notification that is briefly show and then automatically disappears.

Later on I intend to also allow the user to inspect an action log through the options page where he would also be able to undo update actions at his own leasure in case he would have missed the notification.

Or am I now needlessly complicating the original solution which was so elegant due to its its simplicity?

with kind regards, 

Jeroen
