### PR TITLE
Domain name filter

### DIFF
--- a/src_chrome/eventPage.js
+++ b/src_chrome/eventPage.js
@@ -51,7 +51,7 @@ function updateBookmarkFromTab(tab,bookmarkTreeNode){
       if (node.url)
       { // node is a bookmark
         // immediately skip bookmarks with a different domain name
-        if( ! hasMatchingDomainName(node.url, trab.url)) {
+        if( ! hasMatchingDomainName(node.url, tab.url)) {
           continue;
         }
 


### PR DESCRIPTION
Only consider bookmarks with an identical domain name for matches.
This seriously improves matching performance by elliminating 99% of all bookmarks on the spot.

This makes a huge difference especially for the fuzzymatch algorithm, which tends to be kind of slow when matching with all bookmarks.

In case of a large collection of bookmarks, roughly 600 in my case, then evaluating the fuzzy match algorithm for all of them can take up to 1.5 seconds introducing a very noticeable and unwanted delay ! Filtering out the bookmarks with non-matching domain name makes the extension very snappy again. The act of clicking the extension button and updating the best matching bookmark happens again seemingly simultaneous (i.e. on the order of millisecond, instead of seconds)

I find that this makes the fuzzyMatch algorithm actually usable in practice. 

Jeroen
