### PR TITLE
add tabs permissions

### DIFF
--- a/src_chrome/manifest.json
+++ b/src_chrome/manifest.json
@@ -14,7 +14,8 @@
   },
   "permissions": [
     "bookmarks",
-    "notifications"
+    "notifications",
+    "tabs" /* per issue 11 */
   ],
   "browser_action": {
       "default_title": "Update Closest Bookmark",


### PR DESCRIPTION
Chrome now requires the tabs permissions for many of the features in chrome.tabs. It seems this addon uses some of those features, and thus isn't currently working.